### PR TITLE
Add support for vc_di credential issue

### DIFF
--- a/aries_cloudagent/anoncreds/issuer.py
+++ b/aries_cloudagent/anoncreds/issuer.py
@@ -666,7 +666,7 @@ class AnonCredsIssuer:
         async with ledger:
             schema_id = await ledger.credential_definition_id2schema_id(cred_def_id)
         schema_result = await anoncreds_registry.get_schema(self.profile, schema_id)
-        cred_def_id = credential_offer["cred_def_id"]
+        cred_def_id = credential_offer["binding_method"]["anoncreds_link_secret"]["cred_def_id"]
         schema_attributes = schema_result.schema_value.attr_names
 
         try:
@@ -700,16 +700,30 @@ class AnonCredsIssuer:
             raw_values[attribute] = str(credential_value)
 
         try:
-            credential = await asyncio.get_event_loop().run_in_executor(
-                None,
-                lambda: Credential.create(
-                    cred_def.raw_value,
-                    cred_def_private.raw_value,
-                    credential_offer,
-                    credential_request,
-                    raw_values,
-                ),
-            )
+            #credential = await asyncio.get_event_loop().run_in_executor(
+            #    None,
+            #    lambda: Credential.create(
+            #        cred_def.raw_value,
+            #        cred_def_private.raw_value,
+            #        credential_offer,
+            #        credential_request,
+            #        raw_values,
+            #    ),
+            #)
+            credential = {
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://w3id.org/security/data-integrity/v2",
+                  {
+                    "@vocab": "https://www.w3.org/ns/credentials/issuer-dependent#"
+                  }
+                ],
+                "type": ["VerifiableCredential"],
+                "issuer": x,
+                "credentialSubject": x,
+                "proof": x,
+                "issuanceDate": "2024-01-10T04:44:29.563418Z"
+            }
         except AnoncredsError as err:
             raise AnonCredsIssuerError("Error creating credential") from err
 

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -143,6 +143,32 @@ class FaberAgent(AriesAgent):
                 }
                 return offer_request
 
+            elif cred_type == CRED_FORMAT_VC_DI:
+                self.cred_attrs[cred_def_id] = {
+                    "name": "Alice Smith",
+                    "date": "2018-05-28",
+                    "degree": "Maths",
+                    "birthdate_dateint": birth_date.strftime(birth_date_format),
+                    "timestamp": str(int(time.time())),
+                }
+
+                cred_preview = {
+                    "@type": CRED_PREVIEW_TYPE,
+                    "attributes": [
+                        {"name": n, "value": v}
+                        for (n, v) in self.cred_attrs[cred_def_id].items()
+                    ],
+                }
+                offer_request = {
+                    "connection_id": self.connection_id,
+                    "comment": f"Offer on cred def id {cred_def_id}",
+                    "auto_remove": False,
+                    "credential_preview": cred_preview,
+                    "filter": {"vc_di": {"cred_def_id": cred_def_id}},
+                    "trace": exchange_tracing,
+                }
+                return offer_request
+
             elif cred_type == CRED_FORMAT_JSON_LD:
                 offer_request = {
                     "connection_id": self.connection_id,
@@ -176,31 +202,6 @@ class FaberAgent(AriesAgent):
                 }
                 return offer_request
 
-            elif cred_type == CRED_FORMAT_VC_DI:
-                self.cred_attrs[cred_def_id] = {
-                    "name": "Alice Smith",
-                    "date": "2018-05-28",
-                    "degree": "Maths",
-                    "birthdate_dateint": birth_date.strftime(birth_date_format),
-                    "timestamp": str(int(time.time())),
-                }
-
-                cred_preview = {
-                    "@type": CRED_PREVIEW_TYPE,
-                    "attributes": [
-                        {"name": n, "value": v}
-                        for (n, v) in self.cred_attrs[cred_def_id].items()
-                    ],
-                }
-                offer_request = {
-                    "connection_id": self.connection_id,
-                    "comment": f"Offer on cred def id {cred_def_id}",
-                    "auto_remove": False,
-                    "credential_preview": cred_preview,
-                    "filter": {"vc_di": {"cred_def_id": cred_def_id}},
-                    "trace": exchange_tracing,
-                }
-                return offer_request
             else:
                 raise Exception(f"Error invalid credential type: {self.cred_type}")
 


### PR DESCRIPTION
Create the "issue credential" message in the correct format.

At this point the holder (Alice) will get an error:

```
Alice      | 2024-03-18 21:07:24,397 aries_cloudagent.messaging.models.base ERROR V20CredIssue message validation error:
Alice      | Traceback (most recent call last):
Alice      |   File "/home/aries/aries_cloudagent/messaging/models/base.py", line 196, in deserialize
Alice      |     schema.loads(obj) if isinstance(obj, str) else schema.load(obj),
Alice      |   File "/home/aries/.local/lib/python3.9/site-packages/marshmallow/schema.py", line 723, in load
Alice      |     return self._do_load(
Alice      |   File "/home/aries/.local/lib/python3.9/site-packages/marshmallow/schema.py", line 910, in _do_load
Alice      |     raise exc
Alice      | marshmallow.exceptions.ValidationError: {'proof': ['Missing data for required field.']}
Alice      | 2024-03-18 21:07:24,398 aries_cloudagent.core.dispatcher ERROR Message parsing failed: Error deserializing message: V20CredIssue schema validation failed, sending problem report
```

... because there is no schema available to validate against the received message.  (I.e. just like there are new schemas for VCDICredAbstractSchema or VCDICredRequestSchema, there needs another schema for the issue credential message.)

Fixed up some of the logic around issuing the credential, next step is to properly handle the holder's credential receipt.
