### PR TITLE
Add 'resolution' functionality for building and running agents seprately

### DIFF
--- a/demo/run_demo
+++ b/demo/run_demo
@@ -4,6 +4,8 @@ shopt -s nocasematch
 
 cd $(dirname $0)
 
+RESOLUTION="$1"
+shift
 AGENT="$1"
 shift
 ARGS=""
@@ -107,8 +109,9 @@ do
     cat <<EOF
 
 Usage:
-   ./demo_run <agent> [OPTIONS]
+   ./demo_run <resolution> <agent> [OPTIONS]
 
+   - <resolution> is one of the docker option to build or run.
    - <agent> is one of alice, faber, acme, performance.
    - Options:
       --events - display on the terminal the webhook events from the ACA-Py agent.
@@ -127,6 +130,15 @@ EOF
   esac
   ARGS="${ARGS:+$ARGS }$i"
 done
+
+if [ "$RESOLUTION" = "build" ]; then
+  DOCKER_RESOLUTION="build"
+elif [ "$RESOLUTION" = "run" ]; then
+  DOCKER_RESOLUTION="run"
+else
+  echo "Please specify whether you want to build or run the agent. Choose from 'build' or 'run'."
+  exit 1
+fi
 
 if [ "$AGENT" = "faber" ]; then
   AGENT_MODULE="faber"
@@ -155,9 +167,13 @@ if [ ! -z "$AGENT_PORT_OVERRIDE" ]; then
   AGENT_PORT_RANGE="$AGENT_PORT-$AGENT_PORT_END"
 fi
 
-echo "Preparing agent image..."
-docker build -t acapy-base -f ../docker/Dockerfile .. || exit 1
-docker build -t faber-alice-demo -f ../docker/Dockerfile.demo --build-arg from_image=acapy-base .. || exit 1
+# 1. Build the agent image
+if [ "$DOCKER_RESOLUTION" = "build" ]; then
+  echo "Preparing agent image..."
+  docker build -t acapy-base -f ../docker/Dockerfile .. || exit 1
+  docker build -t faber-alice-demo -f ../docker/Dockerfile.demo --build-arg from_image=acapy-base .. || exit 1
+  exit 0
+fi
 
 if [ ! -z "$DOCKERHOST" ]; then
   # provided via APPLICATION_URL environment variable
@@ -262,9 +278,16 @@ if [ "$OSTYPE" = "msys" ]; then
 fi
 DOCKER=${DOCKER:-docker}
 
-$DOCKER run --name $AGENT --rm -it ${DOCKER_OPTS} \
-  --network=${DOCKER_NET} \
-  -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
-  ${DOCKER_VOL} \
-  $DOCKER_ENV \
-  faber-alice-demo $AGENT_MODULE --port $AGENT_PORT $ARGS
+# 2. Run the agent
+if [ "$DOCKER_RESOLUTION" = "run" ]; then
+  echo "Running agent $AGENT..."
+  $DOCKER run --name $AGENT --rm -it ${DOCKER_OPTS} \
+    --network=${DOCKER_NET} \
+    -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
+    ${DOCKER_VOL} \
+    -v $(pwd)/../aries_cloudagent:/home/aries/aries_cloudagent \
+    -v $(pwd)/../scripts:/home/aries/scripts \
+    -v $(pwd)/../demo:/home/aries/demo \
+    $DOCKER_ENV \
+    faber-alice-demo $AGENT_MODULE --port $AGENT_PORT $ARGS
+fi

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -5,9 +5,15 @@ shopt -s nocasematch
 cd $(dirname $0)
 
 RESOLUTION="$1"
-shift
-AGENT="$1"
-shift
+# Check if RESOLUTION is not provided or not a valid option
+if [ -z "$RESOLUTION" ] || [ "$RESOLUTION" != "build" -a "$RESOLUTION" != "run" ]; then
+  echo "Resolution not specified or invalid."
+  AGENT="$1"  # If RESOLUTION is not provided or invalid, assume argument is AGENT
+else
+  shift  # Shift only if RESOLUTION is provided and valid
+  AGENT="$1"
+fi
+shift  # Shift again to remove AGENT from the arguments
 ARGS=""
 
 TRACE_ENABLED=""
@@ -131,14 +137,18 @@ EOF
   ARGS="${ARGS:+$ARGS }$i"
 done
 
-if [ "$RESOLUTION" = "build" ]; then
+if [ -z "$RESOLUTION" ]; then
+  echo "Resolution not specified."
+elif [ "$RESOLUTION" = "build" ]; then
   DOCKER_RESOLUTION="build"
+  echo "Agent will be build."
 elif [ "$RESOLUTION" = "run" ]; then
   DOCKER_RESOLUTION="run"
+  echo "Agent will be run."
 else
-  echo "Please specify whether you want to build or run the agent. Choose from 'build' or 'run'."
-  exit 1
+  echo "You can utilize the 'build' option to build the agent or the 'run' option to run the agent."
 fi
+
 
 if [ "$AGENT" = "faber" ]; then
   AGENT_MODULE="faber"
@@ -168,11 +178,16 @@ if [ ! -z "$AGENT_PORT_OVERRIDE" ]; then
 fi
 
 # 1. Build the agent image
-if [ "$DOCKER_RESOLUTION" = "build" ]; then
+if [ -z "$DOCKER_RESOLUTION" ] || [ "$DOCKER_RESOLUTION" = "build" ]; then
   echo "Preparing agent image..."
   docker build -t acapy-base -f ../docker/Dockerfile .. || exit 1
   docker build -t faber-alice-demo -f ../docker/Dockerfile.demo --build-arg from_image=acapy-base .. || exit 1
-  exit 0
+fi
+
+if [ "$DOCKER_RESOLUTION" = "build" ]; then
+  exit 1
+else
+  echo "You can utilize the 'build' option to build the agent or the 'run' option to run the agent."
 fi
 
 if [ ! -z "$DOCKERHOST" ]; then
@@ -278,16 +293,14 @@ if [ "$OSTYPE" = "msys" ]; then
 fi
 DOCKER=${DOCKER:-docker}
 
-# 2. Run the agent
-if [ "$DOCKER_RESOLUTION" = "run" ]; then
-  echo "Running agent $AGENT..."
-  $DOCKER run --name $AGENT --rm -it ${DOCKER_OPTS} \
+$DOCKER run --name $AGENT --rm -it ${DOCKER_OPTS} \
     --network=${DOCKER_NET} \
     -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
     ${DOCKER_VOL} \
-    -v $(pwd)/../aries_cloudagent:/home/aries/aries_cloudagent \
-    -v $(pwd)/../scripts:/home/aries/scripts \
-    -v $(pwd)/../demo:/home/aries/demo \
+    $(if [ "$DOCKER_RESOLUTION" = "run" ]; then
+      echo "-v $(pwd)/../aries_cloudagent:/home/aries/aries_cloudagent \
+      -v $(pwd)/../scripts:/home/aries/scripts \
+      -v $(pwd)/../demo:/home/aries/demo"
+    fi) \
     $DOCKER_ENV \
     faber-alice-demo $AGENT_MODULE --port $AGENT_PORT $ARGS
-fi


### PR DESCRIPTION
- Introduced the 'resolution' functionality to the run_demo script
- Added support for building the agent image using 'build'
- Implemented the ability to start the agent container with 'start' with host files mounted into docker container
- Updated the script to handle the 'resolution' command with its options(build & run)