### PR TITLE
Allow option to switch cred type in demo and integration tests

### DIFF
--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -28,6 +28,7 @@ Feature: RFC 0453 Aries agent issue credential
     Examples:
        | Acme_capabilities                          | Bob_capabilities              | Schema_name    | Credential_data          | Acme_extra | Bob_extra |
        | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |            |           |
+       | --public-did --wallet-type askar-anoncreds --cred-type vc_di | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |   |   |
 
     @GHA @WalletType_Askar_AnonCreds @AltTests
     Examples:
@@ -46,6 +47,26 @@ Feature: RFC 0453 Aries agent issue credential
        | Acme_capabilities                                                | Bob_capabilities                                                 | Schema_name    | Credential_data          | Acme_extra        | Bob_extra         |
        | --did-exchange --wallet-type askar-anoncreds                     | --did-exchange --wallet-type askar-anoncreds                     | driverslicense | Data_DL_NormalizedValues | --emit-did-peer-4 | --emit-did-peer-4 |
        | --did-exchange --wallet-type askar-anoncreds --reuse-connections | --did-exchange --wallet-type askar-anoncreds --reuse-connections | driverslicense | Data_DL_NormalizedValues | --emit-did-peer-4 | --emit-did-peer-4 |
+
+  @T003-RFC0453
+  Scenario Outline: Issue a credential with the Issuer beginning with an offer
+    Given we have "2" agents
+      | name  | role    | capabilities        | extra        |
+      | Acme  | issuer  | <Acme_capabilities> | <Acme_extra> |
+      | Bob   | holder  | <Bob_capabilities>  | <Bob_extra>  |
+    And "Acme" and "Bob" have an existing connection
+    And "Acme" is ready to issue a credential for <Schema_name>
+    When "Acme" offers a credential with data <Credential_data>
+    When "Bob" has the credential issued
+    When "Acme" sets the credential type to <New_Cred_Type>
+    When "Acme" offers a credential with data <Credential_data>
+    Then "Bob" has the credential issued
+
+    @WalletType_Askar_AnonCreds @SwitchCredTypeTest
+    Examples:
+       | Acme_capabilities                          | Bob_capabilities              | Schema_name    | Credential_data          | Acme_extra | Bob_extra | New_Cred_Type |
+       | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |            |           | vc_di         |
+       | --public-did --wallet-type askar-anoncreds --cred-type vc_di | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |            |           | indy          |
 
   @T003-RFC0453
   Scenario Outline: Holder accepts a deleted credential offer

--- a/demo/features/steps/0453-issue-credential.py
+++ b/demo/features/steps/0453-issue-credential.py
@@ -51,6 +51,15 @@ def step_impl(context, issuer, schema_name):
     context.cred_def_id = cred_def_id
 
 
+@when('"{issuer}" sets the credential type to {credential_type}')
+def step_impl(context, issuer, credential_type):
+    agent = context.active_agents[issuer]
+
+    agent["agent"].set_cred_type(credential_type)
+
+    assert agent["agent"].cred_type == credential_type
+
+
 @given('"{issuer}" offers a credential with data {credential_data}')
 @when('"{issuer}" offers a credential with data {credential_data}')
 def step_impl(context, issuer, credential_data):

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -710,6 +710,9 @@ class AriesAgent(DemoAgent):
 
         return result
 
+    def set_cred_type(self, new_cred_type: str):
+        self.cred_type = new_cred_type
+
 
 class AgentContainer:
     def __init__(
@@ -926,6 +929,10 @@ class AgentContainer:
             self.cred_def_id = await self.create_schema_and_cred_def(
                 schema_name, schema_attrs
             )
+
+    def set_cred_type(self, new_cred_type: str):
+        self.cred_type = new_cred_type
+        self.agent.set_cred_type(new_cred_type)
 
     async def create_schema_and_cred_def(
         self,

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -561,6 +561,15 @@ async def main(args):
         exchange_tracing = False
         options = (
             "    (1) Issue Credential\n"
+        )
+        if faber_agent.cred_type in [
+            CRED_FORMAT_INDY,
+            CRED_FORMAT_VC_DI,
+        ]:
+            options += (
+                "    (1a) Set Credential Type (%CRED_TYPE%)\n"
+            )
+        options += (
             "    (2) Send Proof Request\n"
             "    (2a) Send *Connectionless* Proof Request (requires a Mobile client)\n"
             "    (3) Send Message\n"
@@ -582,7 +591,7 @@ async def main(args):
             "5/6/7/8/" if faber_agent.revocation else "",
             "W/" if faber_agent.multitenant else "",
         )
-        async for option in prompt_loop(options):
+        async for option in prompt_loop(options.replace("%CRED_TYPE%", faber_agent.cred_type)):
             if option is not None:
                 option = option.strip()
 
@@ -635,6 +644,21 @@ async def main(args):
                         "ON" if exchange_tracing else "OFF"
                     )
                 )
+
+            elif option == "1a":
+                new_cred_type = await prompt(
+                    "Enter credential type ({}, {}): ".format(
+                        CRED_FORMAT_INDY,
+                        CRED_FORMAT_VC_DI,
+                    )
+                )
+                if new_cred_type in [
+                    CRED_FORMAT_INDY,
+                    CRED_FORMAT_VC_DI,
+                ]:
+                    faber_agent.set_cred_type(new_cred_type)
+                else:
+                    log_msg("Not a valid credential type.")
 
             elif option == "1":
                 log_status("#13 Issue credential offer to X")

--- a/docs/gettingStarted/AriesDeveloperDemos.md
+++ b/docs/gettingStarted/AriesDeveloperDemos.md
@@ -21,3 +21,12 @@ and then use your new wallet to get and present credentials in some sample scena
 verifiable credential experience in 30 minutes or less.
 
 [BC Gov Showcase]: https://digital.gov.bc.ca/digital-trust/showcase/
+
+## Indicio Developer Demo
+
+Minimal Aca-Py demo that can be used by developers to isolat and test features:
+
+- Minimal Setup (everything runs in containers)
+- Quickly reproduce an issue or demonstrate a feature by writing one simple script or pytest tests.
+
+[Indicio Aca-Py Minimal Example](https://github.com/Indicio-tech/acapy-minimal-example)


### PR DESCRIPTION
... so we can issue both indy and vc_di credentials with the demo and unit tests, without a restart of the agent/demo.

(We will need to test legacy proof requests with vc_di-issued credentials and visa versa.)

